### PR TITLE
typescript 2.6 compatible

### DIFF
--- a/jsmpeg.d.ts
+++ b/jsmpeg.d.ts
@@ -1,70 +1,69 @@
+declare module "jsmpeg"{
 
-export default {
-    Player: Player
-};
+    export class Player {
+        options: PlayerOptions;
+        source: VideoSource;
 
-export class Player {
-    options: PlayerOptions;
-    source: VideoSource;
+        maxAudioLag: number;
+        loop: boolean;
+        autoplay: boolean;
+        isPlaying: boolean;
 
-    maxAudioLag: number;
-    loop: boolean;
-    autoplay: boolean;
-    isPlaying: boolean;
+        demuxer: any;
 
-    demuxer: any;
+        constructor(url: string, options: PlayerOptions);
 
-    constructor(url: string, options: PlayerOptions);
+        showHide(): void;
 
-    showHide(): void;
+        play(): void;
+        pause(): void;
+        stop(): void;
+        destroy(): void;
+        update(): void;
+        updateForStreaming(): void;
+        updateForStaticFile(): void;
 
-    play(): void;
-    pause(): void;
-    stop(): void;
-    destroy(): void;
-    update(): void;
-    updateForStreaming(): void;
-    updateForStaticFile(): void;
+        seek(): void;
 
-    seek(): void;
+        getCurrentTime(): number;
+        getVolume(): number;
+        setVolume(): void;
+    }
 
-    getCurrentTime(): number;
-    getVolume(): number;
-    setVolume(): void;
-}
+    export interface PlayerOptions {
+        canvas?: Element;
+        protocols?: string;
+        audio?: boolean;
+        loop?: boolean;
+        streaming?: boolean;
+        pauseWhenHidden?: boolean;
+        source?: boolean;
+        progressive?: boolean;
+        maxAudioLag?: number;
+        autoplay?: boolean;
+        video?: boolean;
+        disableGl?: boolean;
+        playingStateChange?: (playingState: boolean) => void;
+    }
 
-export interface PlayerOptions {
-    canvas?: Element;
-    protocols?: string;
-    audio?: boolean;
-    loop?: boolean;
-    streaming?: boolean;
-    pauseWhenHidden?: boolean;
-    source?: boolean;
-    progressive?: boolean;
-    maxAudioLag?: number;
-    autoplay?: boolean;
-    video?: boolean;
-    disableGl?: boolean;
-    playingStateChange?: (playingState: boolean) => void;
-}
+    export interface VideoSource {
+        destroy(): void;
+    }
 
-export interface VideoSource {
-    destroy(): void;
-}
+    export class WebSocket implements VideoSource {
+        public url: string;
+        public options: PlayerOptions;
+        public socket: any;
 
-export class WebSocket implements VideoSource {
-    public url: string;
-    public options: PlayerOptions;
-    public socket: any;
+        constructor(url: string, options: PlayerOptions);
 
-    constructor(url: string, options: PlayerOptions);
+        connect(): void;
+        destroy(): void;
+        start(): void;
+        resume(): void;
+        onOpen(): void;
+        onClose(): void;
+        onMessage(): void;
+    }
 
-    connect(): void;
-    destroy(): void;
-    start(): void;
-    resume(): void;
-    onOpen(): void;
-    onClose(): void;
-    onMessage(): void;
 }


### PR DESCRIPTION
de typescript compiler bokte op deze vanwege een breaking change in typescript 2.6:
[https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#arbitrary-expressions-are-forbidden-in-export-assignments-in-ambient-contexts](https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#arbitrary-expressions-are-forbidden-in-export-assignments-in-ambient-contexts)

export default {
    Player: Player
};
